### PR TITLE
Bug fix and optimize

### DIFF
--- a/FixBlizzardRaidAggro.lua
+++ b/FixBlizzardRaidAggro.lua
@@ -1,54 +1,67 @@
 -- IMPORTANT!!!
--- Make sure you disable Interface -> Raid Profiles -> "Display Aggro Highlight"
+-- Make sure you disable Interface -> Raid Profiles -> "Display Aggro Highlight", and do a /reload
 -- If that option is enabled, the following code will not run so we don't mess with the Blizzard PVE aggro
 
+-- Test mode: target a raid frame and check if the aggro highlight is showing up
 local isTestMode = false;
 
+-- Events to reset the aggro
+local EVENT_ENTERWORLD = "PLAYER_ENTERING_WORLD";
+local EVNET_ARENA_OPP = "ARENA_OPPONENT_UPDATE";
+local EVENT_ARENA_PREP = "ARENA_PREP_OPPONENT_SPECIALIZATIONS";
+
+-- For raid frames inside arena, checking the first 10 should be more than enough to cover part members (players and pets)
+local MAX_ARENAOPPONENT_SIZE = 3;
+local MAX_RAIDAGGRO_SIZE = 10;
+
+local function shouldClearAggro(event)
+    return (event == EVENT_ENTERWORLD) or (event == EVNET_ARENA_OPP) or (event == EVENT_ARENA_PREP);
+end
+
 local IsUnitArena = function(unitId)
-    -- Test mode: target yourself and check if the aggro highlight is shown
     if isTestMode then return unitId == "player" end
 
-    for i = 1,3 do
+    for i = 1, MAX_ARENAOPPONENT_SIZE do
         if (unitId == "arena"..i) then
             return true;
         end
     end
 end
 
+local function getAggroUnitGUID()
+    if isTestMode then
+        return UnitGUID("playertarget");
+    end
+
+    local unitAggro = {};
+
+    for i = 1, MAX_ARENAOPPONENT_SIZE do
+        local guidTarget = UnitGUID("arena"..i.."target");
+        if guidTarget then
+            unitAggro[guidTarget] = 1 + (unitAggro[guidTarget] or 0);
+            if (unitAggro[guidTarget] > 1) then
+                return guidTarget;
+            end
+        end
+    end
+end
+
 local eventHandler = function(frame, event, unitTarget)
-    if (event == "PLAYER_ENTERING_WORLD") then
-        -- Upon entering a new zone, clear the aggro
-        for i = 1, 10 do
+    if shouldClearAggro(event) then
+        -- Upon entering a new zone, clear the aggro highlight
+        for i = 1, MAX_RAIDAGGRO_SIZE do
             local frame = _G["CompactRaidFrame"..i];
             if (not frame) or frame.optionTable.displayAggroHighlight then return end
             frame.aggroHighlight:Hide();
         end
     elseif (event == "UNIT_TARGET") and IsUnitArena(unitTarget) then
-        local aggro = {};
-        local guidAggro;
+        local aggroUnitGUID = getAggroUnitGUID();
         
-        for i = 1, 3 do
-            local guidTarget = UnitGUID("arena"..i.."target");
-            if guidTarget then
-                aggro[guidTarget] = 1 + (aggro[guidTarget] or 0);
-                if (aggro[guidTarget] > 1) then
-                    guidAggro = guidTarget;
-                end
-            end
-        end
-        
-        if isTestMode then
-            guidAggro = UnitGUID(unitTarget.."target");
-        end
-        
-        for i = 1, 10 do
+        for i = 1, MAX_RAIDAGGRO_SIZE do
             local frame = _G["CompactRaidFrame"..i];
             if (not frame) or frame.optionTable.displayAggroHighlight then return end
             
-            local showAggro = false;
-            if frame.unit and UnitGUID(frame.unit) == guidAggro then
-                showAggro = true;
-            end
+            local showAggro = frame.unit and (UnitGUID(frame.unit) == aggroUnitGUID);
             
             if showAggro then
                 frame.aggroHighlight:SetVertexColor(GetThreatStatusColor(3)); -- red
@@ -61,7 +74,9 @@ local eventHandler = function(frame, event, unitTarget)
 end
 
 local frame = CreateFrame("Frame");
+frame:RegisterEvent(EVENT_ENTERWORLD);
+frame:RegisterEvent(EVNET_ARENA_OPP);
+frame:RegisterEvent(EVENT_ARENA_PREP);
 frame:RegisterEvent("UNIT_TARGET");
-frame:RegisterEvent("PLAYER_ENTERING_WORLD");
 frame:SetScript("OnEvent", eventHandler);
 

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -423,7 +423,7 @@ local durationTrigger = function(category, allstates, event, ...)
             if allstates[guid] then
                 local state = allstates[guid];
                 state.show = false;
-                state.change = true;
+                state.changed = true;
                 return true;
             end
         end
@@ -596,7 +596,7 @@ BoopUtilsWA.Triggers.CooldownHOJ = function(allstates, event, ...)
                 local cost = GetSpellPowerCost(spellID);
                 if (cost and cost[1] and cost[1].type == spell.powerType and cost[1].cost > 0) then
                     state.expirationTime = state.expirationTime - cost[1].cost * 2;
-                    state.change = true;
+                    state.changed = true;
                     return true;
                 end
             end
@@ -638,7 +638,7 @@ BoopUtilsWA.Triggers.CooldownVendetta = function(allstates, event, ...)
             local cost = GetSpellPowerCost(spellID);
             if (cost and cost[1] and cost[1].type == spell.powerType) then
                 state.expirationTime = state.expirationTime - cost[1].cost / 30;
-                state.change = true;
+                state.changed = true;
                 return true;
             end
         end
@@ -684,7 +684,7 @@ BoopUtilsWA.Triggers.CooldownCombust = function (allstates, event, ...)
                 local resets = spell.resets;
                 if resets[spellID] then
                     state.expirationTime = state.expirationTime - resets[spellID];
-                    state.change = true;
+                    state.changed = true;
                     return true;
                 end
             elseif (subEvent == SUBEVENT_DMG) then
@@ -694,7 +694,7 @@ BoopUtilsWA.Triggers.CooldownCombust = function (allstates, event, ...)
                         local crit = select(21, ...);
                         if crit then
                             state.expirationTime = state.expirationTime - 1;
-                            state.change = true;
+                            state.changed = true;
                             return true;
                         end
                     end
@@ -720,7 +720,7 @@ BoopUtilsWA.Triggers.GlowForSpell = function(spell, allstates, event, ...)
             if allstates[sourceGUID] then
                 local state = allstates[sourceGUID];
                 state.show = false;
-                state.change = true;
+                state.changed = true;
                 return true;
             end
         else

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -624,16 +624,18 @@ BoopUtilsWA.Triggers.CooldownVendetta = function(allstates, event, ...)
         -- Return if no valid target
         if (not sourceGUID) then return end
 
+        local spell = spellData_Vendetta;
+
         -- start HOJ timer (instant spells do not trigger cast start)
-        if (spellID == spellData_Vendetta.spellID) then
-            if isSourceArena(sourceGUID) then
-                allstates[sourceGUID] = makeAllState(spellData_Vendetta, spellData_Vendetta.spellID, spellData_Vendetta.cooldown);
+        if (spellID == spell.spellID) then
+            if checkSpellEnabled(spell, subEvent, sourceGUID) then
+                allstates[sourceGUID] = makeAllState(spell, spell.spellID, spell.cooldown);
                 return true;
             end
         elseif allstates[sourceGUID] and (subEvent == SUBEVENT_CAST) and isSourceArena(sourceGUID) then
             local state = allstates[sourceGUID];
             local cost = GetSpellPowerCost(spellID);
-            if (cost and cost[1] and cost[1].type == spellData_Vendetta.powerType) then
+            if (cost and cost[1] and cost[1].type == spell.powerType) then
                 state.expirationTime = state.expirationTime - cost[1].cost / 30;
                 state.change = true;
                 return true;

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -64,7 +64,7 @@ local arenaInfo = {
     -- Key: unitId (arena1, arena2, arena3), value: sourceGUID
     GUID = {},
     -- Key: sourceGUID, value: unitId (needed for spells that do not TRACK_UNIT, but we still need the unitId, e.g., cauterize)
-    -- Naturally this should always be available since arenaGUID will always be called first to update this.
+    -- Naturally this should always be available since arenaUnitGUID will always be called first to update this.
     unitId = {},
 
     -- Only supports arena1/2/3 via GetArenaOpponentSpec

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -327,7 +327,7 @@ end
 -- Check spell cooldown options, including charges and opt_lower_cooldown, and update allstates
 -- guid: sourceGUID-spellID
 -- Return value: whether state changed, remaining charges
-local function Util_CheckCooldownOptions(allstates, guid, spell, spellID, unitTarget)
+local function checkCooldownOptions(allstates, guid, spell, spellID, unitTarget)
     -- Spell used again within cooldown timer (allstates[guid] not nil could be a glow timer that's not showing cooldown)
     -- If charge is enabled, put the 2nd charge on cooldown
     if allstates[guid] then
@@ -489,7 +489,7 @@ local function cooldownTrigger(category, allstates, event, ...)
         if checkSpellEnabled(spell, subEvent, sourceGUID) then
             local guid = sourceGUID.."-"..spellID;
             local unit = arenaInfo.unitId[sourceGUID];
-            return Util_CheckCooldownOptions(allstates, guid, spell, spellID, unit);
+            return checkCooldownOptions(allstates, guid, spell, spellID, unit);
         end
     end
 end
@@ -766,13 +766,13 @@ local function baselineCooldownTrigger(baselineSpellID, allstates, event, ...)
             if (not spell) then return end
 
             local guid = UnitGUID(unitTarget).."-"..spellID;
-            return Util_CheckCooldownOptions(allstates, guid, spell, spellID, unitTarget);
+            return checkCooldownOptions(allstates, guid, spell, spellID, unitTarget);
         end
     end
 end
 BoopUtilsWA.Triggers.BaselineCooldown = baselineCooldownTrigger;
 
-local function Util_MakeIconState(spell, spellID, unitTarget)
+local function makeIconState(spell, spellID, unitTarget)
     local state = {
         show = true,
         changed = true,
@@ -809,7 +809,7 @@ local function baselineIconTrigger(baselineSpellID, allstates, event, ...)
             if match then -- class/race matches, show icon if not currently shown
                 local guid = UnitGUID(unitTarget) .. "-" .. baselineSpellID;
                 if (not allstates[guid]) then
-                    allstates[guid] = Util_MakeIconState(spell, baselineSpellID, unitTarget);
+                    allstates[guid] = makeIconState(spell, baselineSpellID, unitTarget);
                     return true;
                 end
             end

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -140,7 +140,7 @@ local function updatePlayerInfo()
     arenaInfo.unitRace[unitId] = select(3, UnitRace(unitId));
 end
 
-local function arenaGUID(unitId, index)
+local function arenaUnitGUID(unitId, index)
     if (not arenaInfo.GUID[unitId]) and UnitExists(unitId) then
         local guid = UnitGUID(unitId);
         updateArenaInfo(guid, unitId, index);
@@ -183,7 +183,7 @@ local function isSourceArena(sourceGUID)
     end
 
     for i = 1,3 do
-        if (sourceGUID == arenaGUID("arena"..i, i)) then
+        if (sourceGUID == arenaUnitGUID("arena"..i, i)) then
             return true;
         end
     end

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -31,7 +31,7 @@ BoopUtilsWA = {};
 BoopUtilsWA.Constants = {};
 BoopUtilsWA.Triggers = {};
 
-local isTestMode = true;
+local isTestMode = false;
 
 -- Event name constants
 local EVENT_ENTERWORLD = "PLAYER_ENTERING_WORLD";

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -313,14 +313,7 @@ local function checkResetSpell(allstates, sourceGUID, resetSpells)
                 state.changed = true;
                 stateChanged = true;
             else
-                local expirationTime = state.expirationTime - amount;
-                -- If after the reduction, the spell comes off cooldown, immediately hide the icon
-                if (GetTime() >= expirationTime) then
-                    state.show = false;
-                else
-                    state.expirationTime = expirationTime;
-                end
-                
+                state.expirationTime = state.expirationTime - amount;
                 state.changed = true;
                 stateChanged = true;
             end
@@ -593,7 +586,6 @@ BoopUtilsWA.Triggers.CooldownHOJ = function(allstates, event, ...)
         -- start HOJ timer (instant spells do not trigger cast start)
         if (spellID == spell.spellID) then
             if checkSpellEnabled(spell, subEvent, sourceGUID) then
-                print(subEvent);
                 allstates[sourceGUID] = makeAllState(spell, spell.spellID, spell.cooldown);
                 return true;
             end
@@ -602,15 +594,7 @@ BoopUtilsWA.Triggers.CooldownHOJ = function(allstates, event, ...)
             if (not arenaInfo.defaultHoJCooldown[sourceGUID]) then
                 local cost = GetSpellPowerCost(spellID);
                 if (cost and cost[1] and cost[1].type == spell.powerType and cost[1].cost > 0) then
-                    local expirationTime = state.expirationTime - cost[1].cost * 2;
-
-                    -- If after the reduction spell comes off cooldown, hide the icon
-                    if (GetTime() >= expirationTime) then
-                        state.show = false;
-                    else
-                        state.expirationTime = expirationTime;
-                    end
-                    
+                    state.expirationTime = state.expirationTime - cost[1].cost * 2;
                     state.change = true;
                     return true;
                 end

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -632,7 +632,7 @@ BoopUtilsWA.Triggers.CooldownVendetta = function(allstates, event, ...)
                 allstates[sourceGUID] = makeAllState(spell, spell.spellID, spell.cooldown);
                 return true;
             end
-        elseif allstates[sourceGUID] and (subEvent == SUBEVENT_CAST) and isSourceArena(sourceGUID) then
+        elseif allstates[sourceGUID] and (subEvent == SUBEVENT_CAST) then
             local state = allstates[sourceGUID];
             local cost = GetSpellPowerCost(spellID);
             if (cost and cost[1] and cost[1].type == spell.powerType) then
@@ -673,7 +673,7 @@ BoopUtilsWA.Triggers.CooldownCombust = function (allstates, event, ...)
 
         local spell = spellData_Combust;
 
-        if (subEvent == SUBEVENT_CAST and spellID == spell.spellID and isSourceArena(sourceGUID)) then
+        if (spellID == spell.spellID and checkSpellEnabled(spell, subEvent, sourceGUID)) then
             -- Start cd timer (since this is single spell, we can just use sourceGUID)
             allstates[sourceGUID] = makeAllState(spell, spell.spellID, spell.cooldown);
             return true;


### PR DESCRIPTION
Bug fix for raid aggro:
1. Return early when we already found a GUID that has aggro (target of 2 arena opponents)
2. More events for clearing the aggro: events when arena opponents change
3. GlowForSpell should call checkSpellEnabled to validate event types (so that one spell doesn't trigger multiple times, e.g., one from SPELL_CAST_SUCCESS, another later from SPELL_AURA_REMOVED
4. Fix vendetta timer (call checkSpellEnabled instead of just checking isSourceArena)
5. Fix the issue some timers are not auto hiding after cd reduction (state.change = true, should be state.changed = true)