### PR TITLE
Fix Shambling Rush

### DIFF
--- a/SpellData.lua
+++ b/SpellData.lua
@@ -181,11 +181,16 @@ NS.spellData = {
         cooldown = 15,
     },
     -- Shambling Rush
-    [91807] = {
+    [47482] = {
+        category = INTERRUPT,
+        cooldown = 30,
+        trackType = TRACK_UNIT,
+    },
+    --[[ [91807] = {
         category = INTERRUPT,
         cooldown = 30,
         trackType = TRACK_PET_AURA, -- Have to track aura to distinguish between regular Leap and Shambling Rush
-    },
+    }, ]]
 
     -- DH
     -- CC

--- a/SpellData.lua
+++ b/SpellData.lua
@@ -90,6 +90,7 @@ NS.trackType = {
     TRACK_AURA = 3,
     TRACK_AURA_FADE = 4, -- SPELL_AURA_REMOVED, e.g., prot pally silence
     TRACK_UNIT = 5, -- UNIT_SPELLCAST_SUCCEEDED, e.g., meta (combat log triggered by auto proc meta)
+    TRACK_UNIT_PET = 6, -- UNIT_SPELLCAST_SUCCEEDED by arenapet..i
 };
 
 local TRACK_PET = NS.trackType.TRACK_PET;
@@ -97,6 +98,7 @@ local TRACK_PET_AURA = NS.trackType.TRACK_PET_AURA;
 local TRACK_AURA = NS.trackType.TRACK_AURA;
 local TRACK_AURA_FADE = NS.trackType.TRACK_AURA_FADE;
 local TRACK_UNIT = NS.trackType.TRACK_UNIT;
+local TRACK_UNIT_PET = NS.trackType.TRACK_UNIT_PET;
 
 NS.defaultIndex = 100;
 
@@ -184,7 +186,7 @@ NS.spellData = {
     [47482] = {
         category = INTERRUPT,
         cooldown = 30,
-        trackType = TRACK_UNIT,
+        trackType = TRACK_UNIT_PET,
     },
     --[[ [91807] = {
         category = INTERRUPT,

--- a/UnitInfoHelpers.lua
+++ b/UnitInfoHelpers.lua
@@ -127,6 +127,14 @@ NS.isUnitArena = function(unitId)
     end
 end
 
+NS.isUnitArenaPet = function (unitId)
+    if NS.isTestMode and ( unitId == "pet" ) then
+        return true
+    end
+
+    return ( string.sub(unitId, 1, 8) == "arenapet" );
+end
+
 NS.arenaUnitId = function (sourceGUID)
     return arenaInfo.unitId[sourceGUID];
 end

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -130,7 +130,7 @@ end
 -- Check whether spell is enabled for UNIT_SPELLCAST_ events
 local function unitSpellEnabled(spell, unitId)
     -- Check if opponent is arena
-    if (not NS.isUnitArena(unitId)) then return end
+    if ( not NS.isUnitArena(unitId) ) and ( not NS.isUnitArenaPet(unitId) ) then return end
 
     -- Check if spell is disabled for current spec
     if spell.spec then

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -130,7 +130,8 @@ end
 -- Check whether spell is enabled for UNIT_SPELLCAST_ events
 local function unitSpellEnabled(spell, unitId)
     -- Check if opponent is arena
-    if ( not NS.isUnitArena(unitId) ) and ( not NS.isUnitArenaPet(unitId) ) then return end
+    if ( spell.trackType == NS.TRACK_UNIT ) and ( not NS.isUnitArena(unitId) ) then return end
+    if ( spell.trackType == NS.TRACK_UNIT_PET ) and ( not NS.isUnitArenaPet(unitId) ) then return end
 
     -- Check if spell is disabled for current spec
     if spell.spec then

--- a/UtilsWA.lua
+++ b/UtilsWA.lua
@@ -130,7 +130,7 @@ end
 -- Check whether spell is enabled for UNIT_SPELLCAST_ events
 local function unitSpellEnabled(spell, unitId)
     -- Check if opponent is arena
-    if ( spell.trackType == NS.TRACK_UNIT ) and ( not NS.isUnitArena(unitId) ) then return end
+    if ( spell.trackType == TRACK_UNIT ) and ( not NS.isUnitArena(unitId) ) then return end
     if ( spell.trackType == NS.TRACK_UNIT_PET ) and ( not NS.isUnitArenaPet(unitId) ) then return end
 
     -- Check if spell is disabled for current spec


### PR DESCRIPTION
Since Shambling Rush and Leap share cooldown, it's better to just track the base spell.
If a DK uses Leap to gab close he won't have it for interrupt later, which I doubt any good would do.