### PR TITLE
Hide raid markers to make room for class icons

### DIFF
--- a/NameplateFilter.lua
+++ b/NameplateFilter.lua
@@ -202,6 +202,11 @@ BoopNameplateFilter.NameplateUpdated = function (self, unitId, unitFrame, envTab
     if ( not unitId ) then return end
     if ( not IsActiveBattlefieldArena() ) and ( not testMode )  then return end
 
+    -- A hack to hide raid icons (to make room for class icons)
+    if unitFrame.PlaterRaidTargetFrame:IsShown() then
+        unitFrame.PlaterRaidTargetFrame:Hide();
+    end
+
     updateBuffFrame(unitFrame, unitId);
     updateCastBar(unitFrame, unitId);
     updateName(unitFrame, unitId);


### PR DESCRIPTION
Use WA to create class icon on top of nameplates, since it's anchored to parent frame, it will inherit the alpha, which is perfect.